### PR TITLE
Fix namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can deploy to your cluster using `make` command.
 $ make deploy
 ```
 
-Canary Controller is installed in `canary-controller-manager` namespace.
+Canary Controller is installed in `canary-controller-system` namespace.
 
 ## Usage
 


### PR DESCRIPTION
## Why

readme に書かれている内容が実際と異なるので修正したい

## What

`canary-controller-manager` → `canary-controller-system`