### PR TITLE
Add kustomization.yaml to resource directories to avoid accumulating resource error

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,15 +18,8 @@ namePrefix: canary-controller-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
-  # Comment the following 3 lines if you want to disable
-  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-  # which protects your /metrics endpoint.
-- ../rbac/auth_proxy_service.yaml
-- ../rbac/auth_proxy_role.yaml
-- ../rbac/auth_proxy_role_binding.yaml
+- ../rbac
+- ../manager
 
 patches:
 - manager_image_patch.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,4 @@
+
+kind: Kustomization
+resources:
+- ./manager.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,10 @@
+kind: Kustomization
+resources:
+- ./rbac_role.yaml
+- ./rbac_role_binding.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+- ./auth_proxy_service.yaml
+- ./auth_proxy_role.yaml
+- ./auth_proxy_role_binding.yaml


### PR DESCRIPTION
## Why

kustomize v4 でも正常に動作するようにするため。

kubectl v1.21 で kustomize の version が上がってしまうため、対応が必要。(Ref: https://github.com/wantedly/infrastructure/issues/11079) 




## What

kustomize v4 で以下のエラーが出るのを修正する。 (いつからこのエラーが出るようになったのかは知らないが…)

```
~/.ghq/github.com/wantedly/canary-controller [2022/07/12 10:33:45] (tomoasleep/fix-kustomize|✔ b4488b2)
_(:3」[＿] kube sandbox kustomize config/default
Error: accumulating resources: accumulation err='accumulating resources from '../rbac/rbac_role.yaml': security; file '/Users/tomoya/.ghq/github.com/wantedly/canary-controller/config/rbac/rbac_role.yaml' is not in or below '/Users/tomoya/.ghq/github.com/wantedly/canary-controller/config/default'': got file 'rbac_role.yaml', but '/Users/tomoya/.ghq/github.com/wantedly/canary-controller/config/rbac/rbac_role.yaml' must be a directory to be a root
failed to exec command: [kubectl kustomize config/default]: exit status 1
```

この手のエラーを調べてみると、ディレクトリの外にある manifest を直接参照することはできないらしい。ということで各ディレクトリに kustomization.yaml を配置してエラーが無いことを確認した。 https://stackoverflow.com/questions/67481924/referring-a-resource-yaml-from-another-directory-in-kustomization

### 差分がないこと確認

diff 取って差分がないことは確認済み。

```
~/.ghq/github.com/wantedly/canary-controller [2022/07/12 11:52:21] (tomoasleep/fix-kustomize|✚1 f64551b)
(ρ _-)ノ kube sandbox kustomize config/default | kube sandbox diff -f -
```